### PR TITLE
Fix for cloudly.pubsub.Pusher.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,18 @@
+# Cloudly requirements
+boto==2.8.0
+redis==2.7.2
+rq==0.3.7
+couchdb==0.8
+python-memcached==1.48
+isodate==0.4.9
+pusher==0.7
+twitter==1.9.4
+pubnub==3.3.1
+pyyaml==3.10
+termcolor==1.1.0
+
+# webapp requirements
 flask==0.9
 requests==1.1.0
 gunicorn==0.17.2
-git+https://github.com/ooda/cloudly.git#egg=cloudly
+git+https://github.com/ooda/cloudly.git@v0.6.0#egg=cloudly-v0.6.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ GITHUB = "github.com/ooda"
 # git+http://username:password@github.com/ooda/package@v0.1.3#egg=package-0.1.3
 #
 dependencies = [
-    ('cloudly', '3.0.0'),
+    ('cloudly', 'master'),
 ]
 
 # Generate links
@@ -30,7 +30,7 @@ dependency_links = [
 ]
 
 github_install_requires = [
-    "{pkg}=={ver}".format(
+    "{pkg}".format(
         pkg=package,
         ver=version,
     )
@@ -49,6 +49,6 @@ setup(
     dependency_links=dependency_links,
     scripts=['bin/env_run.sh'],
     install_requires=[
-        'flask==0.9',
+        'flask',
     ] + github_install_requires
 )

--- a/webapp/publish.py
+++ b/webapp/publish.py
@@ -3,7 +3,7 @@ from cloudly.tweets import Tweets, StreamManager, keep
 
 from webapp import config
 
-pubsub = Pusher.open(config.pubsub_channel)
+pubsub = Pusher(config.pubsub_channel)
 
 
 def processor(tweets):


### PR DESCRIPTION
No more `open` method.
Requirements were also modified.
